### PR TITLE
Add Python .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Byte-compiled files
+__pycache__/
+*.pyc
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+
+# Others
+*.pyo
+*.pyd


### PR DESCRIPTION
## Summary
- add a standard .gitignore for Python builds

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406d755c048323a24a90017b94c2ad